### PR TITLE
Code until snake generation is (hopefully) bug-free now

### DIFF
--- a/include/mockturtle/networks/klut.hpp
+++ b/include/mockturtle/networks/klut.hpp
@@ -607,6 +607,9 @@ public:
     if ( n == 0 || is_ci( n ) )
       return;
 
+    if ( is_dangling( n ) )
+      return;
+
     using IteratorType = decltype( _storage->outputs.begin() );
     detail::foreach_element_transform<IteratorType, uint32_t>(
         _storage->nodes[n].children.begin(), _storage->nodes[n].children.end(), []( auto f ) { return f.index; }, fn );


### PR DESCRIPTION
1. Fixed the bug that the representative output ports of T1 cells are not associated with representatives;
2. Fixed the bug that the gate type of the substituted output ports of T1 cells (i.e., the symbolic output ports) is also set to 'T1_GATE';
3. Integrated 'is_dangling' check into the 'foreach_fanin' function.