### PR TITLE
Generated constraints for the timing requirement on the inputs to T1 gates

### DIFF
--- a/include/mockturtle/networks/klut.hpp
+++ b/include/mockturtle/networks/klut.hpp
@@ -607,6 +607,20 @@ public:
     if ( n == 0 || is_ci( n ) )
       return;
 
+    // if ( is_dangling( n ) )
+    //   return;
+
+    using IteratorType = decltype( _storage->outputs.begin() );
+    detail::foreach_element_transform<IteratorType, uint32_t>(
+        _storage->nodes[n].children.begin(), _storage->nodes[n].children.end(), []( auto f ) { return f.index; }, fn );
+  }
+
+  template<typename Fn>
+  void foreach_valid_fanin( node const& n, Fn&& fn ) const
+  {
+    if ( n == 0 || is_ci( n ) )
+      return;
+
     if ( is_dangling( n ) )
       return;
 


### PR DESCRIPTION
1. move 'is_dangling' check from 'foreach_fanin' to 'foreach_valid_fanin';
2. updated function 'dff_vars_single_paths_t1';
3. created function 'sectional_snake_t1', which is still under development to support the constraints generation when inputs of T1 gates are (1) negated, or (2) from confluence buffers.